### PR TITLE
chore(github): add issue forms, PR template, funding & issue labeler

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+# Supported funding model platforms
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: TheWidlarzGroup
+custom:
+  - https://sdk.thewidlarzgroup.com/?utm_source=rnv&utm_medium=github-funding&utm_campaign=sponsor-button

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,168 @@
+name: 🐛 Bug report
+description: Report a bug or unexpected behavior in react-native-video
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! 🙏
+
+        **Before you continue:**
+        - 🔎 Search [existing issues](https://github.com/TheWidlarzGroup/react-native-video/issues) — your problem may already be reported.
+        - ⬆️ Reproduce on the **latest** release. Fixes land on `v7` (and `v6` maintenance).
+        - 🛑 **v5 and older are no longer maintained.** Please upgrade to **v6/v7** (where we fix issues), or use [commercial support](https://sdk.thewidlarzgroup.com/issue-booster?contact=true&utm_source=rnv&utm_medium=issue&utm_campaign=v5-support&utm_id=v5-support) if you must stay on v5. v5 reports are closed automatically.
+        - 💡 Feature idea or usage question? This is **not** the place — use the links on the "New issue" screen (Discussions).
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: Please confirm the following before submitting.
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: I reproduced this on the latest release of react-native-video.
+          required: true
+        - label: This is a bug report, not a usage question (questions belong in Discussions → Q&A).
+          required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead. Screenshots or a screen recording help a lot.
+      placeholder: "Playing an HLS stream on Android, the video freezes after ~3s while audio keeps playing. I expected smooth playback."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps for us to reproduce the bug.
+      placeholder: |
+        1. Render <Video source={{ uri: '...' }} />
+        2. Start playback
+        3. Observe the freeze after a few seconds
+    validations:
+      required: true
+
+  - type: input
+    id: reproduction-repo
+    attributes:
+      label: Reproduction repository
+      description: A link to a minimal repo (or the example app modified) that reproduces the bug. Reports without a reproduction are much harder to fix.
+      placeholder: https://github.com/your-username/rnv-bug-repro
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Required information
+
+  - type: input
+    id: rnv-version
+    attributes:
+      label: react-native-video version
+      description: The exact version from your package.json.
+      placeholder: 7.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: react-native-version
+    attributes:
+      label: React Native version
+      description: The exact version from your package.json.
+      placeholder: 0.81.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Platforms
+      description: Which platforms does the bug occur on?
+      multiple: true
+      options:
+        - iOS
+        - Android
+        - Web
+        - visionOS
+        - Apple tvOS
+        - Android TV
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: system-version
+    attributes:
+      label: OS version
+      description: The OS version of the device/simulator where you see the bug.
+      placeholder: iOS 18.2 / Android 15
+    validations:
+      required: true
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device
+      description: Where are you running the app?
+      multiple: true
+      options:
+        - Real device
+        - Simulator / Emulator
+    validations:
+      required: true
+
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Architecture
+      description: Which React Native architecture are you using?
+      options:
+        - New Architecture
+        - Old Architecture
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Additional information (optional)
+
+        The more you provide, the faster we can help.
+
+  - type: dropdown
+    id: source-type
+    attributes:
+      label: Media / source type
+      description: What kind of media are you playing?
+      options:
+        - HLS (.m3u8)
+        - DASH (.mpd)
+        - MP4 / progressive
+        - Local file
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: expo
+    attributes:
+      label: Expo
+      description: "Are you using Expo? (Note: react-native-video doesn't work in Expo Go — you need a Dev Client.)"
+      options:
+        - No (bare / React Native CLI)
+        - Yes (Expo Dev Client)
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        🚀 **Need this fixed fast, or want dedicated support?** [TheWidlarzGroup](https://sdk.thewidlarzgroup.com/issue-booster?contact=true&utm_source=rnv&utm_medium=issue&utm_campaign=bug-report&utm_id=fix-it-fast) — the maintainers of react-native-video — offer priority support and custom development.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💼 Priority / commercial support
+    url: https://sdk.thewidlarzgroup.com/issue-booster?contact=true&utm_source=rnv&utm_medium=issue&utm_campaign=issue-chooser&utm_id=commercial-support
+    about: Need it fixed fast or want dedicated help? TheWidlarzGroup (the maintainers) offer priority support and custom development.
+  - name: 💡 Feature request
+    url: https://github.com/TheWidlarzGroup/react-native-video/discussions/categories/ideas
+    about: Have an idea? Propose and discuss new features in Discussions → Ideas.
+  - name: ❓ Question / Help
+    url: https://github.com/TheWidlarzGroup/react-native-video/discussions/categories/q-a
+    about: Usage questions and how-to help — ask the community in Discussions → Q&A.
+  - name: 💬 Discord (TheWidlarzGroup)
+    url: https://discord.gg/7Y6eE62hXM
+    about: Chat with the community and maintainers on Discord.
+  - name: 💬 VideoDev Slack (#react-native-video)
+    url: https://join.slack.com/t/video-dev/shared_invite/zt-24kgmctuv-2z0O9J_v6q_rg~x1RujdOA
+    about: Find us in the #react-native-video channel on the VideoDev Slack.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+<!--
+Thanks for opening a pull request! 🙏
+
+To help us review and merge it quickly:
+- Keep the PR focused on a single concern — split unrelated changes into separate PRs.
+- Update the docs (`docs/`) and the README when you change or add public API, props, or events.
+- Link the issue this PR addresses with "Fixes #<number>".
+-->
+
+## Summary
+
+<!-- A clear, concise description of what this PR does. -->
+
+## Motivation
+
+<!-- Why is this change needed? Link the related issue, e.g. "Fixes #1234". -->
+
+## Changes
+
+<!-- A short bullet list of the notable changes. -->
+
+-
+
+## Platforms affected
+
+<!-- Check all that apply. -->
+
+- [ ] Android
+- [ ] iOS
+- [ ] visionOS
+- [ ] tvOS / Android TV
+- [ ] Windows
+- [ ] Web
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation only
+
+## Test plan
+
+<!-- How did you verify the change? Include steps, a sample source/URL, config, and the expected behavior. Screenshots or a screen recording help a lot. -->
+
+## Checklist
+
+- [ ] I read the [contributing guidelines](https://github.com/TheWidlarzGroup/react-native-video/blob/master/CONTRIBUTING.md).
+- [ ] I updated the documentation / README where relevant.
+- [ ] This PR is focused on a single concern.
+- [ ] I tested my changes on at least one platform.

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,115 @@
+name: Issue labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    if: ${{ github.repository == 'TheWidlarzGroup/react-native-video' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            if (!issue) return;
+            const number = issue.number;
+            const body = issue.body || '';
+
+            // Parse the "### Header\n value" sections produced by GitHub issue forms.
+            const sections = {};
+            let header = null;
+            for (const line of body.split(/\r?\n/)) {
+              const m = line.match(/^###\s+(.+?)\s*$/);
+              if (m) { header = m[1].trim(); sections[header] = ''; continue; }
+              if (header != null) sections[header] += line + '\n';
+            }
+
+            // Only act on our bug-report form; ignore free-form / maintainer issues.
+            if (!('Platforms' in sections) && !('react-native-video version' in sections)) {
+              return;
+            }
+
+            const get = (h) => (sections[h] || '').trim();
+            const isEmpty = (v) => !v || v === '_No response_';
+
+            const toAdd = new Set();
+            const toRemove = new Set();
+
+            // Platforms -> platform:* labels
+            const PLATFORM = {
+              'iOS': 'platform: iOS',
+              'Android': 'platform: Android',
+              'Web': 'platform: Web',
+              'visionOS': 'platform: visionOS',
+              'Apple tvOS': 'platform: tvOS',
+              'Android TV': 'platform: Android TV',
+              'Windows': 'platform: Windows',
+            };
+            const platforms = get('Platforms');
+            if (!isEmpty(platforms)) {
+              for (const p of platforms.split(/[,\n]/).map((s) => s.trim()).filter(Boolean)) {
+                if (PLATFORM[p]) toAdd.add(PLATFORM[p]);
+              }
+            }
+
+            // Reproduction repository -> repro provided / missing repro (bidirectional)
+            const repro = get('Reproduction repository');
+            if (!isEmpty(repro) && /https?:\/\/\S+/.test(repro)) {
+              toAdd.add('repro provided');
+              toRemove.add('missing repro');
+            } else {
+              toAdd.add('missing repro');
+              toRemove.add('repro provided');
+            }
+
+            // react-native-video version major -> v5 / v6 / v7
+            const version = get('react-native-video version');
+            const major = (version.match(/^\s*v?(\d+)\./) || [])[1];
+            let isV5 = false;
+            if (major === '7') toAdd.add('v7');
+            else if (major === '6') toAdd.add('v6');
+            else if (major === '5') { toAdd.add('v5'); isV5 = true; }
+
+            const currentLabels = (issue.labels || []).map((l) => (typeof l === 'string' ? l : l.name));
+
+            // Apply / remove labels.
+            const labelsToAdd = [...toAdd].filter((l) => !currentLabels.includes(l));
+            if (labelsToAdd.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: labelsToAdd });
+            }
+            for (const l of toRemove) {
+              if (currentLabels.includes(l)) {
+                try {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name: l });
+                } catch (e) { /* label already absent — ignore */ }
+              }
+            }
+
+            // v5 is unsupported: comment + close as not planned (only once).
+            if (isV5 && issue.state === 'open' && !currentLabels.includes('v5')) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: number,
+                body: [
+                  "👋 Thanks for the report — but **react-native-video v5 and older are no longer maintained**.",
+                  "",
+                  "Please upgrade to **v6 or v7**, where we actively fix issues. If you must stay on v5, [TheWidlarzGroup offers commercial support](https://sdk.thewidlarzgroup.com/issue-booster?contact=true&utm_source=rnv&utm_medium=issue&utm_campaign=v5-support&utm_id=v5-support).",
+                  "",
+                  "Closing as not planned — feel free to re-open on a supported version. 🙏",
+                ].join("\n"),
+              });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+            }


### PR DESCRIPTION
## Summary

Adds a complete `.github` issue & contribution setup (preview PR on the fork to review how it looks).

- **`ISSUE_TEMPLATE/bug-report.yml`** — structured bug report form: prerequisites checkboxes, description-first ordering, required env fields (rnv/RN version, platforms incl. Web, OS, device, architecture), optional video-specific fields (media/source type, Expo). Placeholders instead of pre-filled junk.
- **`ISSUE_TEMPLATE/config.yml`** — disables blank issues; routes **feature requests → Discussions/Ideas** and **questions → Discussions/Q&A**; surfaces commercial support (2nd), Discord, Slack.
- **`PULL_REQUEST_TEMPLATE.md`** — summary / motivation / changes / platforms / type of change / test plan / checklist.
- **`FUNDING.yml`** — GitHub Sponsors + `sdk.thewidlarzgroup.com`.
- **`workflows/issue-labeler.yml`** — deterministic labels from form fields (`platform:*`, `v5/v6/v7`, `missing repro ↔ repro provided`); auto-closes unsupported **v5** reports.

## Notes

- ⚠️ To actually activate, this must land on **`master` of the upstream repo** — GitHub reads templates/workflows only from the default branch.
- Labels auto-create on first run; pre-creating them gives nicer colors (optional).
- Copy is still being polished.

